### PR TITLE
Add library matching the name of the package

### DIFF
--- a/emux.el
+++ b/emux.el
@@ -1,0 +1,45 @@
+;;; emux-base.el --- Emacs Lisp Behaviour-Driven Development framework
+
+;; Copyright (C) 2011 atom smith
+
+;; Author: atom smith
+;; URL: http://trickeries.com/emux
+;; Created: 19 Jan 2011
+;; Version: 0.1
+;; Keywords: terminal multiplexer
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is NOT part of GNU Emacs.
+
+;; This is free software; you can redistribute it and/or modify it under
+;; the terms of the GNU General Public License as published by the Free
+;; Software Foundation; either version 3, or (at your option) any later
+;; version.
+
+;; This file is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+;; General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with Emacs; see the file COPYING, or type `C-h C-c'. If not,
+;; write to the Free Software Foundation at this address:
+
+;; Free Software Foundation
+;; 51 Franklin Street, Fifth Floor
+;; Boston, MA 02110-1301
+;; USA
+
+;;; Commentary:
+
+;; This package implements an Emacs Lisp Behaviour-Driven Development
+;; framework.
+
+;;; Code:
+
+(require 'emux-screen)
+
+(provide 'emux)
+
+;;; emux.el ends here


### PR DESCRIPTION
Every Emacs package should provide a library whose name matches that of the package.  This convention is [almost universally](https://emacsmirror.net/stats/kludges.html#org04b0b94) followed and allows users to easily find the entry point and tools to extract metadata such as the package description.

Speaking of metadata, you might also want to improve the package description.  As it stands now, it is unclear what this package does.  The summary line of all files say "Emacs Lisp Behaviour-Driven Development framework", but this also/instead seems to implement a "terminal multiplexer".